### PR TITLE
Clean Imports

### DIFF
--- a/Input_Files/create_basic_characteristics_table.py
+++ b/Input_Files/create_basic_characteristics_table.py
@@ -1,5 +1,11 @@
+import yt
+import yt.units as u
+import caesar
+from tqdm import tqdm
+import pandas as pd
+import numpy as np
+
 def create_basic_table(boxsize,ytfilename,caesarfilename):
-    
     yt_snap = yt.load(ytfilename)
     yt_data = yt_snap.all_data()
     obj = caesar.load(caesarfilename)

--- a/Input_Files/create_basic_characteristics_table.py
+++ b/Input_Files/create_basic_characteristics_table.py
@@ -42,7 +42,7 @@ def create_basic_table(boxsize,ytfilename,caesarfilename):
         df_aux = pd.DataFrame({'g_Index':gal_index, 'c_Index':clouds_in_this_galaxy, 'c_Mass':Mcloud, 'c_Radius':Rcloud,
                            'c_nDensity':n_density, 'c_Temperature':temp, 'c_Pressure':P, 'c_Metallicity':Metallicity,
                            'g_SFR':sfr_gal, 'g_Redshift':redshift, 'g_Mass_Gas':Mgas_gal, 'g_Mass_H2':MH2_gal, 'g_Radius':R_gal, 'g_Metallicity':Metal_gal})
-        df = df.append(df_aux)
+        df = pd.concat([df, df_aux])
 
     df = df.reset_index(drop=True)
     df['g_Index'] = df['g_Index'].astype('int')

--- a/Input_Files/create_cloudspercore_list.py
+++ b/Input_Files/create_cloudspercore_list.py
@@ -1,3 +1,9 @@
+import yt
+import caesar
+import random
+import numpy as np
+from tqdm import tqdm
+
 def create_param_file(boxsize,ytfilename,caesarfilename,mode,n_galaxies_sample,min_mass,max_mass):
     yt_snap305 = yt.load(ytfilename)
     yt_snap305_data = yt_snap305.all_data()
@@ -30,5 +36,5 @@ def create_param_file(boxsize,ytfilename,caesarfilename,mode,n_galaxies_sample,m
                     f.write(str(galaxies_list[g][1][c])+' ')
                 f.write('\n')
         f.close()
-        
+
     return paramfilename

--- a/Input_Files/limfunctions.py
+++ b/Input_Files/limfunctions.py
@@ -1,38 +1,33 @@
 # densityPrifile and submm_luminosity functions were slightly adapted from the code developed in Popping et al., 2019
 
-import os
+# import os
 import numpy as np
-import scipy
-import matplotlib.pyplot as plt
+# import scipy
+# import matplotlib.pyplot as plt
 from datetime import datetime
-from datetime import timedelta
-import caesar
-import yt
+# from datetime import timedelta
+# import caesar
+# import yt
 import pandas as pd
 import seaborn as sns
-import sys
-from despotic import cloud,zonedcloud
+# import sys
+# from despotic import cloud
+from despotic import zonedcloud
 from despotic.chemistry import NL99_GC
 from astropy import units as u
 from astropy import constants as constants
-from astropy.cosmology import WMAP9 as cosmo
-from scipy.integrate import quad
-import argparse
+# from astropy.cosmology import WMAP9 as cosmo
+# from scipy.integrate import quad
+# import argparse
 sns.set_theme()
-import scipy.constants as physcons
-import yt.units as u
-import random
+# import scipy.constants as physcons
+# import yt.units as u
+# import random
 
 DMR = 1.# Dust-to-metal ratio
 mu_atom = 2.33 #atomic weight
 
 def densityProfile(mass,size,NZONES = 25, ProfileType = 'Plummer'):
-    
-    from astropy import units as u
-    
-    #idk why I have to import this inside of the function, but this is the only way it's working
-    #from astropy import units as u
-    
     Radii = np.linspace(0*u.pc,size,NZONES+1)
     radii = (Radii[1:]+ Radii[:-1])/2
     dR = np.abs(Radii[1:] - Radii[:-1])
@@ -60,9 +55,6 @@ def densityProfile(mass,size,NZONES = 25, ProfileType = 'Plummer'):
     return density, dR.to(u.cm)
 
 def submm_luminosity(INPUT, NZONES=25, ProfileType = 'Powerlaw',noClump = False):
-    
-    from astropy import units as u
-    
     Mcloud,Rcloud,Metallicity,RadField,redshift = INPUT[0], INPUT[1], INPUT[2], INPUT[3], INPUT[4]
     Mcloud *= u.Msun
     Rcloud *= u.pc

--- a/Input_Files/limfunctions.py
+++ b/Input_Files/limfunctions.py
@@ -223,7 +223,6 @@ def creating_table(gal_id,cloud_list,df_basic,date):
     #fails_sfr=0
 
     for c in cloud_list:
-            
         Mcloud = float(df_basic['c_Mass'][df_basic['c_Index']==c])
         Rcloud = float(df_basic['c_Radius'][df_basic['c_Index']==c])
         Metallicity = float(df_basic['c_Metallicity'][df_basic['c_Index']==c])
@@ -237,11 +236,11 @@ def creating_table(gal_id,cloud_list,df_basic,date):
         #if Metallicity > 1e-3 and Pressure > 100: #see if I can run without these requirements
         try:
             out = submm_luminosity([Mcloud,Rcloud,Metallicity,RadField,redshift],NZONES=8)
-            df = df.append({'Galaxy_ID':int(gal_id), 'Cloud_ID':int(c), 'Mcloud':out[0], 'Rcloud':out[1], 'Metallicity':out[2], 'RadField':out[3], 'redshift':out[4], 'H2_lcii':out[5], 'CO10':out[6], 'CO21':out[7], 'CO32':out[8], 'CO43':out[9], 'CO54':out[10], 'CO10_intTB':out[11], 'CO21_intTB':out[12], 'CO32_intTB':out[13], 'CO43_intTB':out[14], 'CO54_intTB':out[15], 'CI10':out[16], 'CI21':out[17], 'CO65':out[18], 'CO76':out[19], 'CO87':out[20], 'CO98':out[21], 'CO65_intTB':out[22], 'CO76_intTB':out[23], 'CO87_intTB':out[24], 'CO98_intTB':out[25], 'OI1':out[26], 'OI2':out[27], 'OI3':out[28], 'fH2':out[29]},ignore_index=True)
+            df = pd.concat([df, pd.DataFrame({'Galaxy_ID':int(gal_id), 'Cloud_ID':int(c), 'Mcloud':out[0], 'Rcloud':out[1], 'Metallicity':out[2], 'RadField':out[3], 'redshift':out[4], 'H2_lcii':out[5], 'CO10':out[6], 'CO21':out[7], 'CO32':out[8], 'CO43':out[9], 'CO54':out[10], 'CO10_intTB':out[11], 'CO21_intTB':out[12], 'CO32_intTB':out[13], 'CO43_intTB':out[14], 'CO54_intTB':out[15], 'CI10':out[16], 'CI21':out[17], 'CO65':out[18], 'CO76':out[19], 'CO87':out[20], 'CO98':out[21], 'CO65_intTB':out[22], 'CO76_intTB':out[23], 'CO87_intTB':out[24], 'CO98_intTB':out[25], 'OI1':out[26], 'OI2':out[27], 'OI3':out[28], 'fH2':out[29]}, index=[0])])
         except:
             print('despoticError, moving on \n despoticError, moving on \n despoticError, moving on \n despoticError, moving on \n despoticError, moving on \n despoticError, moving on \n')
             print('>>>>>>>> galaxy '+str(g)+', cloud '+str(c)+' FAILED due to despotic')
-            df = df.append({'Galaxy_ID':int(gal_id), 'Cloud_ID':int(c), 'Mcloud':-99, 'Rcloud':-99, 'Metallicity':-99, 'RadField':-99, 'redshift':-99, 'H2_lcii':-99, 'CO10':-99, 'CO21':-99, 'CO32':-99, 'CO43':-99, 'CO54':-99, 'CO10_intTB':-99, 'CO21_intTB':-99, 'CO32_intTB':-99, 'CO43_intTB':-99, 'CO54_intTB':-99, 'CI10':-99, 'CI21':-99, 'CO65':-99, 'CO76':-99, 'CO87':-99, 'CO98':-99, 'CO65_intTB':-99, 'CO76_intTB':-99, 'CO87_intTB':-99, 'CO98_intTB':-99, 'OI1':-99, 'OI2':-99, 'OI3':-99, 'fH2':-99},ignore_index=True)
+            df = pd.concat([df, pd.DataFrame({'Galaxy_ID':int(gal_id), 'Cloud_ID':int(c), 'Mcloud':-99, 'Rcloud':-99, 'Metallicity':-99, 'RadField':-99, 'redshift':-99, 'H2_lcii':-99, 'CO10':-99, 'CO21':-99, 'CO32':-99, 'CO43':-99, 'CO54':-99, 'CO10_intTB':-99, 'CO21_intTB':-99, 'CO32_intTB':-99, 'CO43_intTB':-99, 'CO54_intTB':-99, 'CI10':-99, 'CI21':-99, 'CO65':-99, 'CO76':-99, 'CO87':-99, 'CO98':-99, 'CO65_intTB':-99, 'CO76_intTB':-99, 'CO87_intTB':-99, 'CO98_intTB':-99, 'OI1':-99, 'OI2':-99, 'OI3':-99, 'fH2':-99}, index=[0])])
             pass
 
         new_dtypes = {'Galaxy_ID': int, 'Cloud_ID': int}

--- a/Input_Files/slick.py
+++ b/Input_Files/slick.py
@@ -28,21 +28,22 @@ mode = 'total'
 #---------------------------------------#
 
 
-import numpy as np
-import caesar
-import yt
+# import numpy as np
+# import caesar
+# import yt
 import pandas as pd
-import seaborn as sns
-import sys
-import yt.units as u
+# import seaborn as sns
+# import sys
+# import yt.units as u
 import argparse
-from tqdm import tqdm
+# from tqdm import tqdm
 import random
 random.seed(10)
 
-from create_param_file import create_param_file
+from create_cloudspercore_list import create_param_file
 from create_basic_characteristics_table import create_basic_table
-from limfunctions import densityProfile, submm_luminosity, creating_table
+# from limfunctions import densityProfile, submm_luminosity
+from limfunctions import creating_table
 
 
 # Creates table with basic characteristics for all the clouds


### PR DESCRIPTION
There are a lot of unused imports in slick.py and other files don't have imports at the top of them at all. I commented the imports out rather than delete them outright so that it is clear which imports were removed.

Additionally, cleaning imports resolved the name conflict between astropy.units and yt.units mentioned in `densityProfile` and affecting `submm_luminosity`.

Apologies for the last 3 commits being a mess. They just a product of me being bad at git unfortunately.